### PR TITLE
fix(reader): skip null rows in auxiliary-array-count decoder

### DIFF
--- a/src/reader/metadata.rs
+++ b/src/reader/metadata.rs
@@ -1786,14 +1786,22 @@ impl AuxiliaryArrayCountDecoder {
             ($index_array:ident, $values_array:ident, $dtype:ty) => {
                 if let Some(values) = $values_array.as_primitive_opt::<$dtype>() {
                     for (i, c) in $index_array.iter().zip(values.iter()) {
-                        if i.unwrap() as usize >= self.counts.len() {
+                        // The index column is nullable: a null row carries no bin to assign (it
+                        // arises e.g. from the empty-chromatogram placeholder a spectra-only
+                        // archive writes, surfacing as a null spectrum_index in the combined
+                        // auxiliary-array-count facet). Skip it rather than `unwrap()`-panicking —
+                        // previously any ion-mobility archive (whose aux-array facet IS read back,
+                        // unlike non-IM files) crashed the reader.
+                        let Some(idx) = i else { continue };
+                        let idx = idx as usize;
+                        if idx >= self.counts.len() {
                             panic!(
                                 "Cannot fit {} rows into {} bins",
                                 batch.num_rows(),
                                 self.counts.len()
                             );
                         }
-                        self.counts[i.unwrap() as usize] = c.unwrap_or_default() as u32;
+                        self.counts[idx] = c.unwrap_or_default() as u32;
                     }
                     true
                 } else {


### PR DESCRIPTION
## fix(reader): skip null rows in the auxiliary-array-count decoder

Found while building **mzML2mzPeak**, a converter that reads mzML / imzML (via
`mzdata`) and writes mzPeak using this crate as the reference writer/reader.

The auxiliary-array-count facet decoder unwrapped the spectrum-index column, which
is nullable. A spectra-only archive writes an empty-chromatogram placeholder row
whose index is null, so reading any such archive (e.g. an ion-mobility dataset)
**panicked** on the `unwrap()`.

Fix: skip null index rows (`let Some(idx) = i else { continue };`) instead of
unwrapping.

`cargo check` clean. One commit, no behavior change for archives without null
placeholder rows.
