### PR TITLE
fix(writer): default ms_level 0 to MS1 instead of panicking

### DIFF
--- a/src/writer/visitor.rs
+++ b/src/writer/visitor.rs
@@ -1748,8 +1748,18 @@ impl SpectrumDetailsBuilder {
             v
         } else {
             match item.ms_level() {
+                // mzML2mzPeak fix: real-world imzML
+                // (e.g. the canonical ms-imaging.org Example-1 3x3 pairs) declares
+                // `MS:1000511 value="0"` with no explicit spectrum-type cvParam. Upstream
+                // panicked here, crashing forward conversion of any ms_level-0 imzML. Default
+                // ms_level 0 (no explicit type) to MS1 spectrum (MS:1000579) with a warning —
+                // the safe imaging default, symmetric with the reverse emitter's ms-level rule.
                 0 => {
-                    panic!("Couldn't infer spectrum type from MS level, no explicit type specified")
+                    log::warn!(
+                        "spectrum has ms_level 0 and no explicit spectrum-type cvParam; \
+                         defaulting to MS1 spectrum (MS:1000579)"
+                    );
+                    curie!(MS:1000579)
                 }
                 1 => curie!(MS:1000579),
                 _ => curie!(MS:1000580),


### PR DESCRIPTION
## fix(writer): default `ms_level == 0` to MS1 instead of panicking

Found while building **mzML2mzPeak**, a converter that reads mzML / imzML (via
`mzdata`) and writes mzPeak using this crate as the reference writer/reader.

`write_spectrum` panicked with *"Couldn't infer spectrum type from MS level"* when
a spectrum reported `ms_level == 0`. Real imzML files do this: the canonical
ms-imaging.org Example-1 (3×3) declares MS:1000511 (ms level) value="0" with no
explicit spectrum-type cvParam, which **crashed** forward conversion outright.

Fix: treat `ms_level == 0` as MS1 (MS:1000579) and emit a `log::warn!` rather than
panicking. Other levels are unchanged.

`cargo check` clean. One commit, no behavior change for spectra with a valid MS
level.
