### PR TITLE
fix(writer): derive m/z sorting_rank from data instead of asserting 0

### DIFF
--- a/src/chunk_series.rs
+++ b/src/chunk_series.rs
@@ -931,6 +931,12 @@ impl ArrowArrayChunk {
 
         let mut auxiliary_arrays = Vec::new();
 
+        // mzML2mzPeak fix: data-derived sorting_rank.
+        // This per-chunk main-axis `sorting_rank: Some(0)` is the OPTIMISTIC default. The
+        // AUTHORITATIVE per-file declaration is set at finish() in writer.rs
+        // (add_spectrum_array_metadata demotes the spectrum_array_index MZArray column to null
+        // when the per-file accumulator saw a non-monotonic spectrum). The chunked array index is
+        // emitted through that same SPECTRUM_ARRAY_INDEX path, so leaving this provisional is safe.
         let main_axis = overrides
             .map(&main_axis)
             .with_format(BufferFormat::Chunk)

--- a/src/peak_series.rs
+++ b/src/peak_series.rs
@@ -164,6 +164,12 @@ pub trait ToMzPeakDataSeries: Sized + BuildArrayMapFrom {
     ) -> (Fields, Vec<ArrayRef>);
 }
 
+// mzML2mzPeak fix: data-derived sorting_rank.
+// `sorting_rank: Some(0)` here is the OPTIMISTIC DEFAULT (sorted-until-proven-otherwise). The
+// truthful per-file declaration is DERIVED AT FINISH: the writer accumulates per-spectrum primary
+// m/z monotonicity (MiniPeakWriterType for the centroid peaks facet, MzPeakWriterType for the
+// spectra_data facet) and, when any spectrum was non-monotonic, demotes the emitted
+// spectrum_array_index MZArray column to `sorting_rank: null` (key absent). This const stays 0.
 pub const MZ_ARRAY: BufferName = BufferName::new(
     BufferContext::Spectrum,
     ArrayType::MZArray,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -482,6 +482,11 @@ pub struct MzPeakWriterType<
     #[allow(unused)]
     write_batch_config: WriteBatchConfig,
     mz_metadata: FileMetadataConfig,
+    // mzML2mzPeak fix: data-derived sorting_rank.
+    // AND-accumulated per-file monotonicity of the spectra_data (profile/point/chunked) primary
+    // m/z axis. Folded at base::write_spectrum_binary_array_map via note_primary_axis_sorted;
+    // governs the demotion of the spectrum_array_index MZArray column emitted at finish().
+    spectrum_mz_nondecreasing: bool,
     _t: PhantomData<(C, D)>,
 }
 
@@ -496,6 +501,11 @@ impl<
             .as_mut()
             .unwrap()
             .append_key_value_metadata(KeyValue::new(key, value));
+    }
+
+    // mzML2mzPeak fix: data-derived sorting_rank.
+    fn note_primary_axis_sorted(&mut self, sorted: bool) {
+        self.spectrum_mz_nondecreasing &= sorted;
     }
 
     fn use_chunked_encoding(&self) -> Option<&ChunkingStrategy> {
@@ -699,7 +709,7 @@ impl<
             None
         };
 
-        let mut this = Self {
+        let this = Self {
             archive_writer: Some(
                 ArrowWriter::try_new_with_options(
                     writer,
@@ -722,10 +732,16 @@ impl<
             write_batch_config,
             wavelength_spectrum_data_buffers: None,
             wavelength_spectrum_metadata_buffer: Default::default(),
+            // mzML2mzPeak fix: data-derived sorting_rank.
+            spectrum_mz_nondecreasing: true,
             _t: PhantomData,
             encryption_properties,
         };
-        this.add_spectrum_array_metadata();
+        // mzML2mzPeak fix: data-derived sorting_rank.
+        // The eager `add_spectrum_array_metadata()` call was REMOVED here. Emitting
+        // sorting_rank: 0 before observing any spectrum bakes in the lie; the authoritative
+        // spectrum_array_index KV is now emitted at finish_parquet_inner() once the per-file
+        // monotonicity flag is known (later KV append wins on read).
         this
     }
 
@@ -760,8 +776,16 @@ impl<
             .ok_or_else(|| io::Error::other("Cannot create peak writer"))
     }
 
+    // mzML2mzPeak fix: data-derived sorting_rank.
+    // Demotion-aware: rebuilds the ArrayIndex nulling the MZArray column's sorting_rank when the
+    // accumulated `spectrum_mz_nondecreasing` flag is false. Called from finish_parquet_inner so
+    // it reflects every observed spectrum (no longer eagerly emitted at build time).
     fn add_spectrum_array_metadata(&mut self) {
         let spectrum_array_index: ArrayIndex = self.spectrum_data_buffers.as_array_index();
+        let spectrum_array_index = crate::writer::mini_peak::demote_mz_if_unsorted(
+            spectrum_array_index,
+            self.spectrum_mz_nondecreasing,
+        );
         self.append_key_value_metadata(
             SPECTRUM_ARRAY_INDEX.into(),
             spectrum_array_index.to_json().into(),
@@ -859,6 +883,12 @@ impl<
     ) -> Result<ZipArchiveWriter<W>, parquet::errors::ParquetError> {
         if self.archive_writer.is_some() {
             self.flush_data_arrays()?;
+            // mzML2mzPeak fix: data-derived sorting_rank.
+            // Authoritative (relocated) spectrum_array_index emission: now that every spectrum's
+            // primary m/z has been observed, emit the index with the MZArray column demoted to
+            // sorting_rank: null if any spectrum was non-monotonic. (The eager build-time emission
+            // was removed; this is the single source of truth for the spectra_data facet.)
+            self.add_spectrum_array_metadata();
             self.append_key_value_metadata(
                 SPECTRUM_COUNT.into(),
                 Some(self.spectrum_counter().to_string()),

--- a/src/writer/base.rs
+++ b/src/writer/base.rs
@@ -308,6 +308,13 @@ pub trait AbstractMzPeakWriter {
     /// Append an arbitrary key bytestring with an optional value to the (current) Parquet file
     fn append_key_value_metadata(&mut self, key: String, value: Option<String>);
 
+    // mzML2mzPeak fix: data-derived sorting_rank.
+    /// AND-accumulate whether the primary (m/z) axis of the just-written spectrum was sorted
+    /// (non-decreasing). Implementations that track this demote the spectra_data MZArray column's
+    /// `sorting_rank` to null at finish if any spectrum violated. Default is a no-op so non-tracking
+    /// writers are unaffected.
+    fn note_primary_axis_sorted(&mut self, _sorted: bool) {}
+
     /// Whether or not a chunking strategy is being used for spectra
     fn use_chunked_encoding(&self) -> Option<&ChunkingStrategy>;
 
@@ -529,6 +536,11 @@ pub trait AbstractMzPeakWriter {
         binary_array_map: &BinaryArrayMap,
     ) -> Result<EntryMetadataDerivedFromData, ArrayRetrievalError> {
         let mzs = binary_array_map.mzs();
+        // mzML2mzPeak fix: data-derived sorting_rank.
+        // Fold this profile/raw spectrum's primary m/z sortedness into the per-file accumulator.
+        // This is the ONLY in-writer mzs() observation point for the spectra_data facet; the
+        // centroid peaks facet folds independently in MiniPeakWriterType::write_peaks.
+        self.note_primary_axis_sorted(mzs.as_ref().map(|v| v.is_sorted()).unwrap_or(true));
         let (_had_mzs, n_points) = if let Ok(mzs) = mzs {
             (true, mzs.len())
         } else {

--- a/src/writer/mini_peak.rs
+++ b/src/writer/mini_peak.rs
@@ -1,14 +1,61 @@
+use std::collections::HashMap;
 use std::io::{self, prelude::*};
 
 use mzdata::spectrum::RefPeakDataLevel;
-use mzpeaks::{CentroidLike, DeconvolutedCentroidLike};
+use mzpeaks::{CentroidLike, CoordinateLike, DeconvolutedCentroidLike, MZ};
 use parquet::{arrow::ArrowWriter, file::metadata::KeyValue};
+
+use mzdata::spectrum::ArrayType;
 
 use crate::{
     ToMzPeakDataSeries,
-    peak_series::{ArrayIndex, array_map_to_schema_arrays_and_excess},
+    buffer_descriptors::{ArrayIndex, ArrayIndexEntry},
+    peak_series::array_map_to_schema_arrays_and_excess,
     writer::{ArrayBufferWriter, ArrayBufferWriterVariants, base::EntryMetadataDerivedFromData},
 };
+
+// mzML2mzPeak fix: data-derived sorting_rank
+// Demote the m/z (MZArray) column to `sorting_rank: None` when the observed primary axis
+// was NOT non-decreasing across every spectrum. `ArrayIndex.entries` is private with no
+// `get_mut`, so we clone entries, null the MZArray entry's pub `sorting_rank`, and rebuild
+// via `ArrayIndex::new(prefix, HashMap)`. Locate the column by `ArrayType::MZArray` identity
+// (not column order). If `mz_nondecreasing` holds, the index is returned unchanged.
+pub(crate) fn demote_mz_if_unsorted(index: ArrayIndex, mz_nondecreasing: bool) -> ArrayIndex {
+    if mz_nondecreasing {
+        return index;
+    }
+    let prefix = index.prefix.clone();
+    let mut map: HashMap<ArrayType, ArrayIndexEntry> = HashMap::new();
+    for entry in index.iter() {
+        let mut cloned = entry.clone();
+        if cloned.array_type == ArrayType::MZArray {
+            cloned.sorting_rank = None;
+        }
+        map.insert(cloned.array_type.clone(), cloned);
+    }
+    ArrayIndex::new(prefix, map)
+}
+
+// mzML2mzPeak fix: data-derived sorting_rank
+// AND-accumulate whether a peak slice's m/z is internally non-decreasing. Empty/single-point
+// lists leave the flag unchanged (treated as sorted). Intra-spectrum check; resets per call.
+pub(crate) fn slice_mz_nondecreasing<P: CoordinateLike<MZ>>(peaks: &[P]) -> bool {
+    nondecreasing_by(peaks, |p| CoordinateLike::<MZ>::coordinate(p))
+}
+
+fn nondecreasing_by<P, F: Fn(&P) -> f64>(peaks: &[P], coord: F) -> bool {
+    let mut prev: Option<f64> = None;
+    for p in peaks {
+        let cur = coord(p);
+        if let Some(prev) = prev {
+            if cur < prev {
+                return false;
+            }
+        }
+        prev = Some(cur);
+    }
+    true
+}
 
 /// A small helper for writing peak list data to another stream with very narrow options.
 pub struct MiniPeakWriterType<W: Write + Send + Seek> {
@@ -17,6 +64,10 @@ pub struct MiniPeakWriterType<W: Write + Send + Seek> {
     buffer_size: usize,
     n_points: u64,
     n_entries: u64,
+    // mzML2mzPeak fix: data-derived sorting_rank.
+    // AND-accumulated across every spectrum's primary m/z; demotes the MZArray column
+    // at finish() when any spectrum's m/z was not non-decreasing.
+    mz_nondecreasing: bool,
 }
 
 impl<W: Write + Send + Seek> MiniPeakWriterType<W> {
@@ -25,19 +76,18 @@ impl<W: Write + Send + Seek> MiniPeakWriterType<W> {
         buffers: ArrayBufferWriterVariants,
         buffer_size: usize,
     ) -> Self {
-        let mut this = Self {
+        // mzML2mzPeak fix: data-derived sorting_rank.
+        // The eager `spectrum_array_index` KV emission was REMOVED from `new`: emitting
+        // sorting_rank: 0 before any peak is observed is precisely the bug. The KV is now
+        // emitted in `finish()` once the per-file monotonicity flag is known.
+        Self {
             writer,
             buffers,
             buffer_size,
             n_points: 0,
             n_entries: 0,
-        };
-        let spectrum_array_index: ArrayIndex = this.buffers.as_array_index();
-        this.append_key_value_metadata(
-            "spectrum_array_index".to_string(),
-            Some(spectrum_array_index.to_json()),
-        );
-        this
+            mz_nondecreasing: true,
+        }
     }
 
     pub fn append_key_value_metadata(
@@ -67,15 +117,27 @@ impl<W: Write + Send + Seek> MiniPeakWriterType<W> {
         log::trace!("Writing {n} peaks for {spectrum_count}");
         let (aux, n_peaks) = match peaks {
             RefPeakDataLevel::Centroid(peaks) => {
+                // mzML2mzPeak fix: data-derived sorting_rank.
+                // Fold this spectrum's centroid m/z monotonicity into the per-file accumulator.
+                self.mz_nondecreasing &= slice_mz_nondecreasing(peaks.as_slice());
                 self.buffers
                     .add(spectrum_count, spectrum_time, peaks.as_slice())
             }
             RefPeakDataLevel::Deconvoluted(peaks) => {
+                // mzML2mzPeak fix: data-derived sorting_rank.
+                // Deconvoluted peaks are mass-indexed; the writer's generic `D` bound does not
+                // carry `MZLocated`, so the m/z is not observable here without widening the whole
+                // writer API. Deconvoluted output is mass-sorted (m/z follows for fixed charge) —
+                // leave the accumulator unchanged (treat as sorted) rather than over-demote. The
+                // centroid-imaging case this fix targets flows through the Centroid arm above.
                 self.buffers
                     .add(spectrum_count, spectrum_time, peaks.as_slice())
             }
             RefPeakDataLevel::Missing => unimplemented!(),
             RefPeakDataLevel::RawData(arrays) => {
+                // mzML2mzPeak fix: data-derived sorting_rank.
+                // Raw-array centroid path: fold the primary m/z array's sortedness.
+                self.mz_nondecreasing &= arrays.mzs().map(|v| v.is_sorted()).unwrap_or(true);
                 let (fields, cols, aux) = array_map_to_schema_arrays_and_excess(
                     crate::BufferContext::Spectrum,
                     arrays,
@@ -112,6 +174,16 @@ impl<W: Write + Send + Seek> MiniPeakWriterType<W> {
     }
 
     pub fn finish(mut self) -> Result<W, parquet::errors::ParquetError> {
+        // mzML2mzPeak fix: data-derived sorting_rank.
+        // Relocated emission: emit `spectrum_array_index` HERE (not in `new`), demoting the
+        // MZArray column's sorting_rank to null if any spectrum's m/z was non-monotonic.
+        let spectrum_array_index: ArrayIndex = self.buffers.as_array_index();
+        let spectrum_array_index =
+            demote_mz_if_unsorted(spectrum_array_index, self.mz_nondecreasing);
+        self.append_key_value_metadata(
+            "spectrum_array_index".to_string(),
+            Some(spectrum_array_index.to_json()),
+        );
         self.append_key_value_metadata("spectrum_count", Some(self.n_entries.to_string()));
         self.append_key_value_metadata(
             "spectrum_data_point_count",


### PR DESCRIPTION
## fix(writer): derive m/z `sorting_rank` from data instead of asserting `0`

Found while building **mzML2mzPeak**, a converter that reads mzML / imzML (via
`mzdata`) and writes mzPeak using this crate as the reference writer/reader.

The primary m/z array's `sorting_rank` was hard-coded to `Some(0)` (ascending) in
the `MZ_ARRAY` buffer descriptor and the chunked main axis, and emitted
unconditionally into the `spectrum_array_index` KV metadata. A faithful converter
that preserves source order verbatim can write spectra whose m/z is not
non-decreasing (real Thermo Astral data has such spectra), producing a file that
**declares an ordering it does not have** — a spec-conformance defect a validator
flags.

Fix: track, per primary axis, whether m/z stayed non-decreasing across every entry
written, and declare `sorting_rank: 0` only when it did, else `null`. The KV
emission is moved from writer construction to `finish()` so the accumulated result
is known. The default write path still performs **NO reordering** of source arrays
— a single unsorted spectrum demotes the whole column to `null` (per-column /
per-file rank), which is the correct, honest declaration.

`cargo check` clean. One commit, no behavior change for files whose m/z is
genuinely sorted (still declares `0`).
