### PR TITLE
fix(chunk_series): index intensity/mz by output position, not source-…

### DIFF
--- a/src/chunk_series.rs
+++ b/src/chunk_series.rs
@@ -967,7 +967,7 @@ impl ArrowArrayChunk {
             return Ok((Vec::new(), auxiliary_arrays, 0));
         }
 
-        for (i, (_, arr)) in arrays.iter().enumerate() {
+        for (_, arr) in arrays.iter() {
             let name = BufferName::from_data_array(main_axis.context, arr);
             let buffer_name0 = if name.array_type == main_axis.array_type {
                 main_axis.clone().with_format(BufferFormat::Chunk)
@@ -993,10 +993,12 @@ impl ArrowArrayChunk {
                     continue;
                 }
             }
+            // Index into `arrow_arrays` (the kept/filtered output), not the source map:
+            // schema-skipped arrays are spilled to auxiliary and never pushed here.
             if matches!(buffer_name.array_type, ArrayType::IntensityArray) {
-                intensity_idx = Some(i);
+                intensity_idx = Some(arrow_arrays.len());
             } else if matches!(buffer_name.array_type, ArrayType::MZArray) {
-                mz_idx = Some(i);
+                mz_idx = Some(arrow_arrays.len());
             }
             let array = data_array_to_arrow_array(&buffer_name, arr)?;
             arrow_arrays.push((buffer_name, array));


### PR DESCRIPTION
## Problem
Fix an index desync in `ArrowArrayChunk::from_arrays` that panics 
when a spectrum carries an array that isn't part of the chunk schema.

`from_arrays` records `intensity_idx`/`mz_idx` as the `enumerate()` index over the source
`BinaryArrayMap`, but later uses them to index `arrow_arrays`, which only contains the arrays
that were *kept*. Arrays not in the chunk schema are dropped, so the indices diverge. 

Triggered by **profile ion-mobility** spectra with a third
per-point array (raw ion mobility). The IM array isn't in the chunk
schema - spilled - index desync; panic ensues. 

## Suggested fix
Record `arrow_arrays.len()` (the slot the kept array will occupy after the push) 
instead of the source-map index. No behavior change for the 
common case where nothing is spilled.