### PR TITLE
add an HRTB to allow trivial bounds to compile with latest rustc

### DIFF
--- a/src/reader/index.rs
+++ b/src/reader/index.rs
@@ -559,7 +559,7 @@ impl<T: PartialEq + PartialOrd + HasProximity> SpanDynNumeric for SimpleInterval
 {
 }
 impl<T: PartialEq + PartialOrd + HasProximity> SpanDynNumeric for CoordinateRange<T> where
-    <mzpeaks::coordinate::CoordinateRange<T> as mzdata::prelude::Span1D>::DimType:
+    for<'trivial_bound> <mzpeaks::coordinate::CoordinateRange<T> as mzdata::prelude::Span1D>::DimType:
         num_traits::NumCast
 {
 }


### PR DESCRIPTION
Hi there! This project surfaced while assessing what potential breakage PR https://github.com/rust-lang/rust/pull/159118 would cause to the Rust ecosystem. The PR fixes a bug in the compiler where some unsatisfiable `where`-clauses would be allowed to compile without error.

Unfortunately, after this fix, this project will no longer compile. To allow it to continue to compile, the simplest workaround that preserves existing functionality is to add a dummy `for<'trivial_bound>` binder around the where-clause in question. I've attempted to do such a minimal change in this PR.

For reference, the full list of build failures caused by the rustc PR can be found here: https://crater-reports.s3.amazonaws.com/pr-159118/index.html